### PR TITLE
perf, refactor: simplify and performe strings

### DIFF
--- a/encode.v
+++ b/encode.v
@@ -1,12 +1,11 @@
 module msgpack
 
-import strings
 import math
 import time
 
 struct Encoder {
 mut:
-	buffer strings.Builder = strings.new_builder(1024)
+	buffer []u8
 	config Config = default_config()
 }
 
@@ -114,9 +113,9 @@ pub fn (mut e Encoder) encode[T](data T) []u8 {
 
 pub fn (mut e Encoder) encode_bool(b bool) {
 	if b {
-		e.buffer.write_u8(mp_true)
+		e.buffer << mp_true
 	} else {
-		e.buffer.write_u8(mp_false)
+		e.buffer << mp_false
 	}
 }
 
@@ -354,7 +353,9 @@ pub fn (mut e Encoder) write_map_start(length int) {
 }
 
 fn (mut e Encoder) write_string(s string) {
-	e.buffer.write_string(s)
+	if s.len > 0 {
+		unsafe { e.buffer.push_many(s.str, s.len) }
+	}
 }
 
 fn (mut e Encoder) write_u16(i u16) {
@@ -379,14 +380,14 @@ pub fn (mut e Encoder) write_f64(f f64) {
 
 // write byte array
 fn (mut e Encoder) write(b []u8) {
-	e.buffer.write(b) or { panic('write error') }
+	unsafe { e.buffer.push_many(b.bytestr().str, b.bytestr().len) }
 }
 
 // write one or more bytes
 fn (mut e Encoder) write_u8(b ...u8) {
 	if b.len > 1 {
-		e.write(b)
+		e.buffer << b
 	} else {
-		e.buffer.write_u8(b[0])
+		e.buffer << b[0]
 	}
 }

--- a/examples/bench_msgpack_json_vs_json2.v
+++ b/examples/bench_msgpack_json_vs_json2.v
@@ -4,18 +4,19 @@ import os
 import json
 import x.json2
 import msgpack
-import time
 import benchmark
+// import time
 
 struct Person {
-	name       string
-	age        int
-	created_at time.Time
+	name string
+	age  int
+	// created_at time.Time
 }
 
 fn main() {
-	max_iterations := os.getenv_opt('MAX_ITERATIONS') or { '1000' }.int()
-	s := '{"name":"Bilbo Baggins","age":99,"created_at":1670840340}'
+	max_iterations := os.getenv_opt('MAX_ITERATIONS') or { '1000000' }.int()
+	// s := '{"name":"Bilbo Baggins","age":99,"created_at":1670840340}'
+	s := '{"name":"Bilbo Baggins","age":99}'
 	mut b := benchmark.start()
 
 	for _ in 0 .. max_iterations {


### PR DESCRIPTION
`msgpack.encode_to_json` is around 3x faster
![image](https://github.com/vlang/msgpack/assets/63821277/30685353-3a30-4591-9afd-88f1960b91db)

previous benchmark
![image](https://github.com/vlang/msgpack/assets/63821277/c4f41502-2b19-4740-9257-ff0fb887fe1b)