### PR TITLE
fix: use minimal integer encoding and decode fixint bytes

### DIFF
--- a/config.v
+++ b/config.v
@@ -37,6 +37,7 @@ struct Config {
 
 pub fn default_config() Config {
 	return Config{
-		write_ext: true
+		write_ext:             true
+		positive_int_unsigned: true
 	}
 }

--- a/decode.v
+++ b/decode.v
@@ -86,7 +86,7 @@ pub fn (mut d Decoder) decode_to_json[T](src []u8) !string {
 			result << `}`
 		}
 		mp_nil {
-			unsafe { result.push_many('null'.str, 'null'.len) }
+			unsafe { result.push_many(c'null', 'null'.len) }
 		}
 		mp_true, mp_false {
 			mut bool_val := false
@@ -132,6 +132,7 @@ pub fn (mut d Decoder) decode_to_json[T](src []u8) !string {
 			return error('unsupported descriptor byte for conversion to JSON')
 		}
 	}
+
 	return result.bytestr()
 }
 

--- a/decode.v
+++ b/decode.v
@@ -98,6 +98,14 @@ pub fn (mut d Decoder) decode_to_json[T](src []u8) !string {
 			d.decode_float(mut float_val) or { return error('error decoding float: ${err}') }
 			unsafe { result.push_many(float_val.str().str, float_val.str().len) }
 		}
+		mp_pos_fix_int_min...mp_pos_fix_int_max {
+			int_val := int(d.bd)
+			unsafe { result.push_many(int_val.str().str, int_val.str().len) }
+		}
+		mp_neg_fix_int_min...mp_neg_fix_int_max {
+			int_val := int(i8(d.bd))
+			unsafe { result.push_many(int_val.str().str, int_val.str().len) }
+		}
 		mp_u8, mp_u16, mp_u32, mp_u64, mp_i8, mp_i16, mp_i32, mp_i64 {
 			mut int_val := 0
 			d.decode_integer(mut int_val) or { return error('error decoding integer: ${err}') }
@@ -170,6 +178,12 @@ pub fn (mut d Decoder) decode[T](data []u8, mut val T) ! {
 pub fn (mut d Decoder) decode_integer[T](mut val T) ! {
 	data := d.buffer
 	match d.bd {
+		mp_pos_fix_int_min...mp_pos_fix_int_max {
+			val = T(d.bd)
+		}
+		mp_neg_fix_int_min...mp_neg_fix_int_max {
+			val = T(i8(d.bd))
+		}
 		mp_u8 {
 			val = T(data[d.pos])
 			d.pos++

--- a/encode.v
+++ b/encode.v
@@ -38,25 +38,24 @@ pub fn (mut e Encoder) encode[T](data T) []u8 {
 	} $else $if T is bool {
 		e.encode_bool(data)
 	}
-	// TODO: if int encode_int, if uint encode_uint
-	// instead of needing to check each type, also
-	// then we will be using the smallest storage
 	$else $if T is i8 {
-		e.encode_i8(data)
+		e.encode_int(i64(data))
 	} $else $if T is i16 {
-		e.encode_i16(data)
+		e.encode_int(i64(data))
 	} $else $if T is int {
-		e.encode_i32(data)
+		e.encode_int(i64(data))
+	} $else $if T is i32 {
+		e.encode_int(i64(data))
 	} $else $if T is i64 {
-		e.encode_i64(data)
+		e.encode_int(data)
 	} $else $if T is u8 {
-		e.encode_u8(data)
+		e.encode_uint(u64(data))
 	} $else $if T is u16 {
-		e.encode_u16(data)
+		e.encode_uint(u64(data))
 	} $else $if T is u32 {
-		e.encode_u32(data)
+		e.encode_uint(u64(data))
 	} $else $if T is u64 {
-		e.encode_u64(data)
+		e.encode_uint(data)
 	} $else $if T is f32 {
 		e.encode_f32(data)
 	} $else $if T is f64 {

--- a/encode.v
+++ b/encode.v
@@ -37,8 +37,7 @@ pub fn (mut e Encoder) encode[T](data T) []u8 {
 		e.encode_string(data)
 	} $else $if T is bool {
 		e.encode_bool(data)
-	}
-	$else $if T is i8 {
+	} $else $if T is i8 {
 		e.encode_int(i64(data))
 	} $else $if T is i16 {
 		e.encode_int(i64(data))
@@ -230,6 +229,7 @@ pub fn (mut e Encoder) encode_string(s string) {
 			container_raw_legacy
 		}
 	}
+
 	e.write_container_len(ct, s.len)
 	if s.len > 0 {
 		e.write_string(s)

--- a/encode_test.v
+++ b/encode_test.v
@@ -11,9 +11,9 @@ struct Struct {
 
 fn test_encoding() {
 	// Test encoding integers
-	assert msgpack.encode(0) == hex.decode('d200000000')!
-	assert msgpack.encode(42) == hex.decode('d20000002a')!
-	assert msgpack.encode(-123) == hex.decode('d2ffffff85')!
+	assert msgpack.encode(0) == hex.decode('00')!
+	assert msgpack.encode(42) == hex.decode('2a')!
+	assert msgpack.encode(-123) == hex.decode('d085')!
 
 	// Test encoding strings
 	assert msgpack.encode('hello') == hex.decode('a568656c6c6f')!
@@ -21,10 +21,10 @@ fn test_encoding() {
 
 	// Test encoding arrays
 	// assert msgpack.encode([]) == hex.decode('90')!
-	assert msgpack.encode([0]) == hex.decode('91d200000000')!
+	assert msgpack.encode([0]) == hex.decode('9100')!
 	assert msgpack.encode([0.0]) == hex.decode('91cb0000000000000000')!
 	assert msgpack.encode(['']) == hex.decode('91a0')!
-	assert msgpack.encode([1, 2, 3]) == hex.decode('93d200000001d200000002d200000003')! // REVIEW
+	assert msgpack.encode([1, 2, 3]) == hex.decode('93010203')!
 
 	// Test encoding maps
 	assert msgpack.encode({
@@ -33,7 +33,7 @@ fn test_encoding() {
 	}) == hex.decode('82a46e616d65a44a6f686ea3616765a23330')!
 
 	// Test encoding struct
-	assert msgpack.encode(Struct{'John', 30}) == hex.decode('82a161a44a6f686ea162d20000001e')!
+	assert msgpack.encode(Struct{'John', 30}) == hex.decode('82a161a44a6f686ea1621e')!
 	// assert msgpack.encode({}) == hex.decode('80')!
 
 	// Test encoding booleans


### PR DESCRIPTION
## Summary

Fixes three interop-breaking bugs in the integer encode/decode paths, reported in vlang/v#26644.

- **Encoder always used the widest int format.** `encode(0)` produced `d2 00 00 00 00` instead of `00`. The generic `encode[T]()` dispatcher bypassed the existing `encode_int`/`encode_uint` functions (which already implement minimal encoding) and called fixed-width helpers directly. Now all integer types route through `encode_int`/`encode_uint`. The missing `i32` case is also added.
- **`positive_int_unsigned` defaulted to `false`.** Non-negative values 128–255 took the signed branch and encoded as 3-byte int16 instead of 2-byte uint8. Default config now sets it to `true`.
- **Decoder ignored positive/negative fixint bytes.** `decode_integer` and `decode_to_json` had no `match` arms for `0x00`–`0x7f` or `0xe0`–`0xff`, so any value in `-32..127` encoded by a spec-compliant library (Python, Rust, Go) — or by this library after the encoder fix — could not be decoded. Both functions now handle the fixint ranges.

`encode_test.v` assertions are updated to the spec-compliant minimal bytes.

## Test plan

- [x] `v test .` — all 3 test files pass (decode, encode, decode_to_json)
- [x] Verified spec bytes against the [MessagePack int format family](https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family):
  - `encode(0)` → `00`, `encode(42)` → `2a`, `encode(127)` → `7f`
  - `encode(-32)` → `e0`, `encode(-123)` → `d0 85`, `encode(-1)` → `ff`
  - `encode(200)` → `cc c8` (uint8, not signed int16)
  - `encode([1,2,3])` → `93 01 02 03`
- [x] Round-trip: `decode(encode(x))` for fixint and uint8 ranges
- [x] Decode of standalone fixint bytes (`2a`, `00`, `fb`, `e0`, `ff`)